### PR TITLE
findall parameter fix

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -25,7 +25,7 @@ for line in stdin:
             entries.append(entry)
             entry = {}
     elif (match('url', line.strip())):
-        value, = findall('\{(\S+)\}', line)
+        value, = findall('{\(\S+)\}', line)
         entry["url"] = value
     elif (search('=', line.strip())):
         key, value = [v.strip(" {},\n") for v in line.split("=")]


### PR DESCRIPTION
Changed [ value, = findall('\{(\S+)\}', line) ] to [ value, = findall('{\(\S+)\}', line) ]