### PR TITLE
Fixed last entry not being printed

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -31,6 +31,8 @@ for line in stdin:
         key, value = [v.strip(" {},\n") for v in line.split("=")]
         entry[key] = value
 
+entries.append(entry)
+
 for entry in entries:
     author = "Anonymous"
     if "author" in entry:


### PR DESCRIPTION
The actual version of the project misses to print the last BiBTeX entry as it is not added to the list of entries.
This pull request fixes this behaviour.