### PR TITLE
Split line from input on the first equal

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -28,7 +28,7 @@ for line in stdin:
         value, = findall('\{(\S+)\}', line)
         entry["url"] = value
     elif (search('=', line.strip())):
-        key, value = [v.strip(" {},\n") for v in line.split("=")]
+        key, value = [v.strip(" {},\n") for v in line.split("=", maxsplit=1)]
         entry[key] = value
 
 entries.append(entry)


### PR DESCRIPTION
The actual version of the project splits each line of the input using `=` as the separator to separate a BibTeX entry name from its value.
However, a `=` character in a entry value adds an additional split, and breaks the script.
By splitting only on the first `=`, occurrence, the result of the split remains an array of length 2, and the `=` in the value remains.
This pull request fixes this behaviour.